### PR TITLE
Bugfix with import statements

### DIFF
--- a/lib/protobuf/compiler/visitors.rb
+++ b/lib/protobuf/compiler/visitors.rb
@@ -102,7 +102,7 @@ module Protobuf
         unless File.exist?(File.join(@out_dir, File.basename(proto_file, '.proto') + '.pb.rb'))
           Compiler.compile(proto_file, @proto_dir, @out_dir)
         end
-        proto_file.sub(/\.proto\z/, '')
+        proto_file.sub(/\.proto\z/, '.pb')
       end
 
       def create_files(filename, out_dir, file_create)


### PR DESCRIPTION
Just a one-line modification to add the .pb extension to the require statements generated from imports in a proto file.
