### PR TITLE
Adds Rake task for compiling protobuf files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ task :test => :check_dependencies
 
 task :default => :test
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/lib/protobuf/generate_task.rb
+++ b/lib/protobuf/generate_task.rb
@@ -1,0 +1,31 @@
+require 'rubygems'
+require 'rake'
+require 'protobuf/compiler/compiler'
+
+module Protobuf
+  class GenerateTask < Rake::TaskLib
+    def initialize(*proto_paths, &block)
+      init(proto_paths)
+
+      define(&block)
+    end
+
+    def init(*proto_paths)
+      @proto_paths = Rake::FileList[proto_paths]
+    end
+
+    def define
+      for protobuf in @proto_paths
+        ruby_protobuf = File.join("lib", File.basename(protobuf, File.extname(protobuf)) + ".pb.rb")
+
+        compile_task = file ruby_protobuf => protobuf do
+          Protobuf::Compiler.compile(protobuf, File.dirname(protobuf), File.dirname(ruby_protobuf))
+        end
+
+        task :protobuf => [ compile_task ]
+
+        yield ruby_protobuf if block_given?
+      end
+    end
+  end
+end

--- a/lib/protobuf/generate_task.rb
+++ b/lib/protobuf/generate_task.rb
@@ -11,11 +11,11 @@ module Protobuf
     end
 
     def init(*proto_paths)
-      @proto_paths = Rake::FileList[proto_paths]
+      @proto_paths = Rake::FileList.new(proto_paths)
     end
 
     def define
-      for protobuf in @proto_paths
+      @proto_paths.each do |protobuf|
         ruby_protobuf = File.join("lib", File.basename(protobuf, File.extname(protobuf)) + ".pb.rb")
 
         compile_task = file ruby_protobuf => protobuf do


### PR DESCRIPTION
Adds "rake/generate_task" which can be used in a Rakefile as follows:

``` ruby
Protobuf::GenerateTask.new("proto/*.proto") do |ruby_protobuf|
  spec.files << ruby_protobuf
end
```

This adds a "protobuf" task, which can be used by executing "rake protobuf". If used as above, it will also run automatically whenever a packaging task occurs, e.g. "package", "build" or "gem". It can also manually be added as a dependency of any other tasks, e.g. "test".
